### PR TITLE
Set initial text coloring to black

### DIFF
--- a/alv/alignment.py
+++ b/alv/alignment.py
@@ -131,7 +131,7 @@ class BaseAlignment:
         colored_seq = ''
         for col_no, c in enumerate(seq_record.seq):
             colored_seq += painter.colorizer(c, self.columns[block.start + col_no])
-        return colored_seq + painter.eol()
+        return painter.sol() + colored_seq + painter.eol()
         
     def _summarize_columns(self):
         '''
@@ -193,7 +193,7 @@ class codonAlignment(BaseAlignment):
         for codon_col, pos in enumerate(range(0, len(seq), 3)):
             c = seq[pos:pos+3]
             colored_seq += painter.colorizer(c, self.columns[block.start // 3 + codon_col])
-        return colored_seq + painter.eol()
+        return painter.sol() + colored_seq + painter.eol()
         
     def _summarize_columns(self):
         '''

--- a/alv/colorize.py
+++ b/alv/colorize.py
@@ -30,6 +30,9 @@ class Painter:
 
     def eol(self):
         return Style.RESET_ALL
+    
+    def sol(self):
+        return Fore.BLACK
 
 # Restriction functions
 #


### PR DESCRIPTION
For colorschemes with non-black font the text becomes illegible against the color of the background. This sets the color of the text to black as a default.