### PR TITLE
Truncation bug

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -1,6 +1,6 @@
 # Project support
 
-* Nikos Tsardakas Renhult helped fixing an unfortunate color choice. He also fixed bugs in
+* Nikos Tsardakas Renhuldt helped fixing an unfortunate color choice. He also fixed bugs in
   --dotted mode, and contributed options --only-variable and --only-variable-excluding-indels.
 * Karin Lagesen @karinlag and Juan Villada @juanvillada had constructive suggestions when reviewing
   the paper for JOSS.

--- a/alv/colorize.py
+++ b/alv/colorize.py
@@ -189,6 +189,8 @@ class DnaPainter(Painter):
             return Back.YELLOW , Back.WHITE
         elif c in 'Gg':
             return Back.RED, Back.WHITE
+        elif c in 'Nn':
+            return Back.WHITE, Back.WHITE
         elif c in '!*':
             return self.color_for_bad_data()
         elif c in '-.:':


### PR DESCRIPTION
When there are Ns in the DNA sequence, the sequence gets truncated. This PR fixes this. It also corrects the spelling of my name.

A separate thing I noticed: The `DnaClassPainter` is currently not used. Is this a feature that's about to be implemented, or should this class be removed to avoid confusion? If it is to be kept, this fix should probably be applied there as well.