### PR TITLE
Get ci pytest workflow to run. 

### DIFF
--- a/.github/workflows/alv_testing.yml
+++ b/.github/workflows/alv_testing.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.8', '3.10', '3.12', '3.x']
-        os: [ubuntu, windows, macos]
+        os: [ubuntu-latest, windows-latest, ubuntu-20.04, macos-latest]
 
     steps:
     - name: Checkout code
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        python -m pip install -e .
+        python -m pip install .
 
     - name: Run tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
       run: |

--- a/.github/workflows/alv_testing.yml
+++ b/.github/workflows/alv_testing.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6.15, 3.8.18, 3.12.9]
+        python-version: ['3.6.15', '3.8.18', '3.12.9', '3.x']
         os: [ubuntu, windows, macos]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/alv_testing.yml
+++ b/.github/workflows/alv_testing.yml
@@ -1,4 +1,4 @@
-name: Alv testing
+name: ALV CI Tests
 
 on:
   push:
@@ -7,25 +7,31 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    name: Pytest on ${{ matrix.os }} - ${{ matrix.python-version }}
+  test:
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6.15', '3.8.18', '3.12.9', '3.x']
+        python-version: ['3.6', '3.8', '3.10', '3.12', '3.x']
         os: [ubuntu, windows, macos]
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: 'Update pip'
-      run: python -m pip install --upgrade pip
+        cache: 'pip'
+
     - name: Install dependencies
       run: |
-        pip install .
-    - name: Test on ${{ matrix.os }} - ${{ matrix.python-version }}
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        python -m pip install -e .
+
+    - name: Run tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
       run: |
         python -m pytest tests/ -v

--- a/.github/workflows/alv_testing.yml
+++ b/.github/workflows/alv_testing.yml
@@ -21,10 +21,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: 'Update pip'
+      run: python -m pip install --upgrade pip
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python setup.py develop
+        pip install .
     - name: Test on ${{ matrix.os }} - ${{ matrix.python-version }}
       run: |
         python -m pytest tests/ -v

--- a/.github/workflows/alv_testing.yml
+++ b/.github/workflows/alv_testing.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   build:
-
+    name: Pytest on ${{ matrix.os }} - ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.6.15, 3.8.18, 3.12.9]
-
+        os: [ubuntu, windows, macos]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -25,6 +25,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python setup.py develop
-    - name: Test with unittest
+    - name: Test on ${{ matrix.os }} - ${{ matrix.python-version }}
       run: |
         python -m pytest tests/ -v


### PR DESCRIPTION
Hi, I noticed that the gihtub ci pytests were still not working correctly. 

This PR should help with that. 

The changes: 
- ${matrix.os} needed to be declared 
- Used less strict python version declarations, as they might not always be available on the newest os.  https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
- It will be difficult to have `alv` run on python `3.6` as transitioning to a `pyproject.toml` due to to metadata not being correctly read. https://discuss.python.org/t/user-experience-with-porting-off-setup-py/37502/53, I don't entirely get it and is out of the scope of this PR. 


 